### PR TITLE
fix: support newlines in PDF footer (issue #38)

### DIFF
--- a/ksef_cli/pdf_generator.py
+++ b/ksef_cli/pdf_generator.py
@@ -658,7 +658,9 @@ class KSeFPDFGenerator:
 
         elements: list = []
         elements.append(HRFlowable(width="100%", thickness=0.5, color=MID_GREY, spaceAfter=4))
-        elements.append(Paragraph(stopka_text.strip(), self.styles["FooterNote"]))
+        # Convert newlines to HTML line breaks for proper display
+        formatted_stopka = stopka_text.strip().replace("\n", "<br/>")
+        elements.append(Paragraph(formatted_stopka, self.styles["FooterNote"]))
         return elements
 
     def _generuj_dodatkowe_opisy(self, root: etree._Element, ns: dict) -> list:

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -336,3 +336,36 @@ class TestKSeFPDFGenerator:
         assert result == output_path
         assert os.path.exists(output_path)
         assert os.path.getsize(output_path) > 0
+
+    def test_pdf_with_multiline_footer(self, sprzedawca, nabywca, tmp_path):
+        """Test PDF generation with multiline footer containing newlines"""
+        pozycja = PozycjaFaktury(
+            nr=1,
+            nazwa="Usługa",
+            jm="szt",
+            ilosc=1.0,
+            cena_netto=100.00,
+            wartosc_netto=100.00,
+            stawka_vat=23,
+        )
+        # Create footer with newlines
+        footer_text = "Linia 1\nLinia 2\nLinia 3"
+        faktura = Faktura(
+            numer="FV/001",
+            data_wystawienia=date(2026, 2, 1),
+            miejsce_wystawienia="Warszawa",
+            data_sprzedazy=date(2026, 2, 1),
+            pozycje=[pozycja],
+            stopka_faktury=footer_text,
+        )
+        faktura_ksef = FakturaKSeF(sprzedawca=sprzedawca, nabywca=nabywca, faktura=faktura)
+
+        xml_generator = KSeFGenerator()
+        xml_content = xml_generator.generuj(faktura_ksef)
+
+        pdf_generator = KSeFPDFGenerator()
+        output_path = str(tmp_path / "output_footer.pdf")
+        result = pdf_generator.generuj_z_xml(xml_content, output_path)
+
+        assert os.path.exists(result)
+        assert os.path.getsize(result) > 0


### PR DESCRIPTION
Handle newlines in invoice footer text by converting them to HTML <br/> tags for proper display in PDF. This aligns with the government KSeF PDF generator behavior which supports multiline footer content.

- Replace \n with <br/> in footer text before rendering
- Add test for multiline footer functionality